### PR TITLE
fix: port config 버그 수정

### DIFF
--- a/config/settings/limiter_config.go
+++ b/config/settings/limiter_config.go
@@ -115,7 +115,7 @@ func validateConfig(config *RootRateLimiterConfig) {
 
 func portConfig(config *RootRateLimiterConfig) {
 	if config.RateLimiter.Port == 0 {
-		config.RedisConfig.Port = 8081 // 포트 기본값 8081
+		config.RateLimiter.Port = 8081 // 포트 기본값 8081
 	}
 }
 


### PR DESCRIPTION
Resolves https://github.com/sapiensXXV/gate-limiter/issues/2

portConfig()가 rate limiter 기본 포트 8081를 의도했지만,
실제로는 `RateLimiter.Port`가 0이면 `RedisConfig.Port`를 8081로 세팅하고 있습니다.