### PR TITLE
fix: RetryAfter 계산 수정

### DIFF
--- a/internal/limiter/strategy/sliding_window_counter_limiter.go
+++ b/internal/limiter/strategy/sliding_window_counter_limiter.go
@@ -96,9 +96,16 @@ func (l *SlidingWindowCounterLimiter) IsAllowed(
 
 	result := float64(currentWindowSize) + float64(size-currentWindowSize)*(float64(api.WindowSeconds-gapFromCurrentStart)/float64(api.WindowSeconds))
 	if int(math.Floor(result)) > api.Limit {
+		retryAt := currentWindowStart.Add(window)
+		wait := retryAt.Sub(now)
+		sec := int(math.Ceil(wait.Seconds()))
+		if sec < 0 {
+			sec = 0
+		}
+
 		return types.RateLimitDecision{
 			Allowed:       false,
-			RetryAfterSec: int(currentWindowStart.Add(time.Duration(api.WindowSeconds) * time.Second).Sub(now)),
+			RetryAfterSec: sec,
 		}
 	}
 


### PR DESCRIPTION
Resolves #6 

`RetryAfterSec`가 `int(duration)`으로 들어가는데, `duration`은 `ns` 단위라서 값이 `초`가 아닌 `나노초 int`로 들어갑니다. `wait.Seconds()` 기반으로 `ceil` 처리해서 음수를 방지했습니다.